### PR TITLE
Add prototype system devicetree for nRF5340

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.dtb
+*.pp
+out-*.dts

--- a/armv8-m-ppb.dtsi
+++ b/armv8-m-ppb.dtsi
@@ -1,0 +1,15 @@
+/*
+ * Common nodes shared by Arm v8-M private peripheral buses (PPBs).
+ */
+
+interrupt-controller@e000e100  {
+	compatible = "arm,v8m-nvic";
+	reg = <0xe000e100 0xc00>;
+	interrupt-controller;
+	#interrupt-cells = <2>;
+};
+
+timer@e000e010 {
+	compatible = "arm,armv8m-systick";
+	reg = <0xe000e010 0x10>;
+};

--- a/dt_bindings.h
+++ b/dt_bindings.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017 Linaro Limited
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _DT_BINDINGS_H_
+#define _DT_BINDINGS_H_
+
+#define DT_SIZE_K(x) ((x) * 1024)
+
+#ifndef NRF_DEFAULT_IRQ_PRIORITY
+#define NRF_DEFAULT_IRQ_PRIORITY 1
+#endif
+
+#define I2C_BITRATE_STANDARD	100000	/* 100 Kbit/s */
+#define I2C_BITRATE_FAST	400000	/* 400 Kbit/s */
+#define I2C_BITRATE_FAST_PLUS	1000000 /* 1 Mbit/s */
+#define I2C_BITRATE_HIGH	3400000	/* 3.4 Mbit/s */
+#define I2C_BITRATE_ULTRA	5000000 /* 5 Mbit/s */
+
+#endif

--- a/lop-cpuapp.dts
+++ b/lop-cpuapp.dts
@@ -1,0 +1,16 @@
+/dts-v1/;
+
+/ {
+        compatible = "system-device-tree-v1,lop";
+        lops {
+                compatible = "system-device-tree-v1,lop";
+                lop_0 {
+                        compatible = "system-device-tree-v1,lop,modify";
+                        modify = "/cpus-cluster@0/::/cpus/";
+                };
+                lop_1 {
+                        compatible = "system-device-tree-v1,lop,modify";
+                        modify = "/cpus-cluster@1/::";
+                };
+        };
+};

--- a/lop-cpunet.dts
+++ b/lop-cpunet.dts
@@ -1,0 +1,16 @@
+/dts-v1/;
+
+/ {
+        compatible = "system-device-tree-v1,lop";
+        lops {
+                compatible = "system-device-tree-v1,lop";
+                lop_0 {
+                        compatible = "system-device-tree-v1,lop,modify";
+                        modify = "/cpus-cluster@1/::/cpus/";
+                };
+                lop_1 {
+                        compatible = "system-device-tree-v1,lop,modify";
+                        modify = "/cpus-cluster@0/::";
+                };
+        };
+};

--- a/nrf5340_system.dts
+++ b/nrf5340_system.dts
@@ -1,0 +1,922 @@
+/*
+ * Copyright (c) 2019, 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "dt_bindings.h"
+
+/dts-v1/;
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	/* Application core cluster ---------------------------------------- */
+
+	cpus-cluster@0 {
+		/* Application core cluster */
+		compatible = "cpus,cluster";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		address-map =
+			<0x0 &app_core_components 0x0 0x01000000>,
+			<0xe0000000 &app_ppb 0xe0000000 0xffffffff>,
+			<0x50000000 &app_s 0x50000000 0x01000000>,
+			<0x40000000 &app_ns 0x40000000 0x01000000>,
+		        /*
+			 * FIXME:
+			 *
+			 * this app_us part forces secure-only addresses
+			 * for user-selectable peripherals. What is the
+			 * right way to handle this in lopper?
+			 */
+			<0x50000000 &app_us 0x0 0x01000000>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m33f";
+			reg = <0>;
+
+			mpu@e000ed90 {
+				compatible = "arm,armv8m-mpu";
+				reg = <0xe000ed90 0x40>;
+				arm,num-mpu-regions = <8>;
+			};
+		};
+	};
+
+	/* Network core cluster -------------------------------------------- */
+
+	cpus-cluster@1 {	/* network core cluster */
+		compatible = "cpus,cluster";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		address-map =
+			<0x1ff0000 &net_core_components 0x1ff0000 0xe010000>,
+			<0x01000000 &net_mem 0x01000000 0x3f000000>,
+			<0xe0000000 &net_ppb 0xe0000000 0xffffffff>,
+			<0x41000000 &net_peripherals 0x41000000 0xf000000>,
+		        /*
+			 * FIXME:
+			 *
+			 * This app_s part assumes accesses from the
+			 * network core are treated as secure, but that's
+			 * configurable.
+			 */
+			<0x50000000 &app_s 0x50000000 0x01000000>,
+			<0x40000000 &app_ns 0x40000000 0x01000000>,
+		        /*
+			 * FIXME:
+			 *
+			 * This app_us part assumes secure-only addresses
+			 * for app core peripherals, but that's part of the
+			 * same configuration bit mentioned above.
+			 *
+			 */
+			<0x50000000 &app_us 0x0 0x01000000>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m33";
+			reg = <0>;
+
+			mpu@e000ed90 {
+				compatible = "arm,armv8m-mpu";
+				reg = <0xe000ed90 0x40>;
+				arm,num-mpu-regions = <8>;
+			};
+		};
+	};
+
+	/* Application resources ------------------------------------------- */
+
+	app_core_components: app-core-components {
+		/*
+		 * Application core, core components. See below for other
+		 * application core peripherals.
+		 */
+		compatible = "indirect-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* skipped: CACHE */
+
+		/* skipped: CACHEDATA */
+
+		/* skipped: CACHEINFO */
+
+		ficr@ff0000 {
+			compatible = "nordic,nrf-ficr";
+			reg = <0xff0000 0x1000>;
+			status = "okay";
+		};
+
+		uicr@ff8000 {
+			compatible = "nordic,nrf-uicr";
+			reg = <0xff8000 0x1000>;
+			status = "okay";
+		};
+	};
+
+	app-mem {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		/*
+		 * FIXME:
+		 *
+		 * Putting this here makes the memory addressable
+		 * from both CPU cluster's address maps (after running
+		 * lopper to move the right one to /cpus), but it
+		 * breaks Zephyr's expectation that a parent/child
+		 * relationship indicates a flash controller.
+		 *
+		 * Do we need to switch to a phandle property, e.g.
+		 * something like
+		 *
+		 *     flash-controller = <&the_app_nvmc_node>;
+		 */
+		flash@0 {	/* app core flash */
+			compatible = "soc-nv-flash";
+			reg = <0x00000000 DT_SIZE_K(1024)>;
+			label = "NRF_FLASH";
+			erase-block-size = <0x1000>;
+			write-block-size = <0x4>;
+		};
+
+		memory@20000000 { /* app core SRAM */
+			compatible = "mmio-sram";
+			reg = <0x20000000 DT_SIZE_K(512)>;
+		};
+	};
+
+	app_ppb: app-ppb {
+		/* App core Arm private peripheral bus */
+		compatible = "indirect-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* skipped: CTI */
+
+		/* skipped: TAD */
+
+		/include/ "armv8-m-ppb.dtsi"
+	};
+
+	app_s: app-s {
+		/*
+		* Application core peripherals, with peripheral IDs,
+		* that are secure-only.
+		*/
+		compatible = "indirect-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* skipped: CACHE */
+
+		spu@50003000 {	/* SPU */
+			compatible = "nordic,nrf-spu";
+			reg = <0x50001000 0x1000>;
+		};
+
+		gpiote@5000d000 { /* GPIOTE0 */
+			compatible = "nordic,nrf-gpiote";
+			reg = <0x5000d000 0x1000>;
+		};
+
+		crypto@50844000 { /* CRYPTOCELL */
+			compatible = "nordic,nrf-cc312";
+			reg = <0x50844000 0x1000>;
+			label = "CRYPTOCELL";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			crypto@50845000 {
+				compatible = "arm,cryptocell-312";
+				reg = <0x50845000 0x1000>;
+				interrupts = <68 NRF_DEFAULT_IRQ_PRIORITY>;
+				label = "CRYPTOCELL312";
+			};
+		};
+	};
+
+	app_ns: app-ns {
+		/*
+		 * Application core peripherals, with peripheral IDs, that are
+		 * always mapped non-secure (just GPIOTE1). These should be
+		 * addressable by all domains, since they are available
+		 * to secure code on the app core as well as the network
+		 * core regardless of its security bit (TODO: verify net part)
+		 */
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		gpiote@4002f000 { /* GPIOTE1 */
+			compatible = "nordic,nrf-gpiote";
+			reg = <0x4002f000 0x1000>;
+			interrupts = <47 5>;
+			status = "disabled";
+			label = "GPIOTE_1";
+		};
+	};
+
+	app_us: app-us {
+		/*
+		 * app core peripherals, with peripheral IDs, whose
+		 * security state / memory map is user-selectable via
+		 * the SPU
+		 */
+		compatible = "indirect-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		dcnf@0 { /* DCNF */
+			compatible = "nordic,nrf-dcnf";
+			reg = <0x0 0x1000>;
+		};
+
+		/* skipped: FPU */
+
+		oscillator@4000 { /* OSCILLATORS */
+			compatible = "nordic,nrf-oscillators";
+			reg = <0x4000 0x1000>;
+		};
+
+		regulator@4000 { /* REGULATORS */
+			compatible = "nordic,nrf-regulators";
+			reg = <0x4000 0x1000>;
+		};
+
+		clock@5000 { /* CLOCK */
+			compatible = "nordic,nrf-clock";
+			reg = <0x5000 0x1000>;
+			interrupts = <0x5 NRF_DEFAULT_IRQ_PRIORITY>;
+			label = "CLOCK";
+		};
+
+		power@5000 { /* POWER */
+			compatible = "nordic,nrf-power";
+			reg = <0x5000 0x1000>;
+			interrupts = <0x5 NRF_DEFAULT_IRQ_PRIORITY>;
+		};
+
+		/* skipped: RESET */
+
+		/* skipped: CTRLAPPERI */
+
+		spi@8000 { /* SPIM0 or SPIS0 */
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0x8000 0x1000>;
+			interrupts = <0x8 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "SPI_0";
+		};
+
+		i2c@8000 { /* TWIM0 or TWIS0 */
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0x8000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <0x8 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "I2C_0";
+		};
+
+		uart@8000 { /* UARTE0 */
+			compatible = "nordic,nrf-uarte";
+			reg = <0x8000 0x1000>;
+			interrupts = <0x8 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "UART_0";
+		};
+
+		spi@9000 { /* SPIM1 or SPIS1 */
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0x9000 0x1000>;
+			interrupts = <0x9 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "SPI_1";
+		};
+
+		i2c@9000 { /* TIM1 or TWIS1 */
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0x9000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <0x9 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "I2C_1";
+		};
+
+		uart@9000 { /* UARTE1 */
+			compatible = "nordic,nrf-uarte";
+			reg = <0x9000 0x1000>;
+			interrupts = <0x9 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "UART_1";
+		};
+
+		spi@a000 { /* SPIM4 */
+			compatible = "nordic,nrf-spim";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0xa000 0x1000>;
+			interrupts = <0xa NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "SPI_4";
+		};
+
+		spi@b000 { /* SPIM2 or SPIS2 */
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0xb000 0x1000>;
+			interrupts = <0xb NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "SPI_2";
+		};
+
+		i2c@b000 { /* TWIM2 or TWIS2 */
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0xb000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <0xb NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "I2C_2";
+		};
+
+		uart@b000 { /* UARTE2 */
+			compatible = "nordic,nrf-uarte";
+			reg = <0xb000 0x1000>;
+			interrupts = <0xb NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "UART_2";
+		};
+
+		spi@c000 { /* SPIM3 or SPIS3 */
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0xc000 0x1000>;
+			interrupts = <0xc NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "SPI_3";
+		};
+
+		i2c@c000 { /* TIM3 or TWIS3 */
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0xc000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <0xc NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "I2C_3";
+		};
+
+		uart@c000 { /* UARTE3 */
+			compatible = "nordic,nrf-uarte";
+			reg = <0xc000 0x1000>;
+			interrupts = <0xc NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "UART_3";
+		};
+
+		adc@e000 { /* SAADC */
+			compatible = "nordic,nrf-saadc";
+			reg = <0xe000 0x1000>;
+			interrupts = <0xe NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "ADC_0";
+			#io-channel-cells = <0x1>;
+		};
+
+		timer@f000 { /* TIMER0 */
+			compatible = "nordic,nrf-timer";
+			status = "disabled";
+			reg = <0xf000 0x1000>;
+			cc-num = <0x6>;
+			interrupts = <0xf NRF_DEFAULT_IRQ_PRIORITY>;
+			prescaler = <0x0>;
+			label = "TIMER_0";
+		};
+
+		timer@10000 { /* TIMER1 */
+			compatible = "nordic,nrf-timer";
+			status = "disabled";
+			reg = <0x10000 0x1000>;
+			cc-num = <0x6>;
+			interrupts = <0x10 NRF_DEFAULT_IRQ_PRIORITY>;
+			prescaler = <0x0>;
+			label = "TIMER_1";
+		};
+
+		timer@11000 { /* TIMER2 */
+			compatible = "nordic,nrf-timer";
+			status = "disabled";
+			reg = <0x11000 0x1000>;
+			cc-num = <0x6>;
+			interrupts = <0x11 NRF_DEFAULT_IRQ_PRIORITY>;
+			prescaler = <0x0>;
+			label = "TIMER_2";
+		};
+
+		rtc@14000 { /* RTC0 */
+			compatible = "nordic,nrf-rtc";
+			reg = <0x14000 0x1000>;
+			cc-num = <0x4>;
+			interrupts = <0x14 NRF_DEFAULT_IRQ_PRIORITY>;
+			clock-frequency = <0x8000>;
+			prescaler = <0x1>;
+			label = "RTC_0";
+		};
+
+		rtc@15000 { /* RTC1 */
+			compatible = "nordic,nrf-rtc";
+			reg = <0x15000 0x1000>;
+			cc-num = <0x4>;
+			interrupts = <0x15 NRF_DEFAULT_IRQ_PRIORITY>;
+			clock-frequency = <0x8000>;
+			prescaler = <0x1>;
+			label = "RTC_1";
+		};
+
+		dppic@17000 { /* DPPIC */
+			compatible = "nordic,nrf-dppic";
+			reg = <0x17000 0x1000>;
+			label = "DPPIC";
+		};
+
+		watchdog@18000 { /* WDT0 */
+			compatible = "nordic,nrf-watchdog";
+			reg = <0x18000 0x1000>;
+			interrupts = <0x18 NRF_DEFAULT_IRQ_PRIORITY>;
+			label = "WDT";
+		};
+
+		watchdog@19000 { /* WDT1 */
+			compatible = "nordic,nrf-watchdog";
+			reg = <0x19000 0x1000>;
+			interrupts = <0x19 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "WDT_1";
+		};
+
+		/* skipped: COMP */
+
+		/* skipped: LPCOMP */
+
+		egu@1b000 { /* EGU0 */
+			compatible = "nordic,nrf-egu";
+			reg = <0x1b000 0x1000>;
+			interrupts = <0x1b NRF_DEFAULT_IRQ_PRIORITY>;
+		};
+
+		egu@1c000 { /* EGU1 */
+			compatible = "nordic,nrf-egu";
+			reg = <0x1c000 0x1000>;
+			interrupts = <0x1c NRF_DEFAULT_IRQ_PRIORITY>;
+		};
+
+		egu@1d000 { /* EGU2 */
+			compatible = "nordic,nrf-egu";
+			reg = <0x1d000 0x1000>;
+			interrupts = <0x1d NRF_DEFAULT_IRQ_PRIORITY>;
+		};
+
+		egu@1e000 { /* EGU3 */
+			compatible = "nordic,nrf-egu";
+			reg = <0x1e000 0x1000>;
+			interrupts = <0x1e NRF_DEFAULT_IRQ_PRIORITY>;
+		};
+
+		egu@1f000 { /* EGU4 */
+			compatible = "nordic,nrf-egu";
+			reg = <0x1f000 0x1000>;
+			interrupts = <0x1f NRF_DEFAULT_IRQ_PRIORITY>;
+		};
+
+		egu@20000 { /* EGU5 */
+			compatible = "nordic,nrf-egu";
+			reg = <0x20000 0x1000>;
+			interrupts = <0x20 NRF_DEFAULT_IRQ_PRIORITY>;
+		};
+
+		pwm@21000 { /* PWM0 */
+			compatible = "nordic,nrf-pwm";
+			reg = <0x21000 0x1000>;
+			interrupts = <0x21 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "PWM_0";
+			#pwm-cells = <0x1>;
+		};
+
+		pwm@22000 { /* PWM1 */
+			compatible = "nordic,nrf-pwm";
+			reg = <0x22000 0x1000>;
+			interrupts = <0x22 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "PWM_1";
+			#pwm-cells = <0x1>;
+		};
+
+		pwm@23000 { /* PWM2 */
+			compatible = "nordic,nrf-pwm";
+			reg = <0x23000 0x1000>;
+			interrupts = <0x23 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "PWM_2";
+			#pwm-cells = <0x1>;
+		};
+
+		pwm@24000 { /* PWM3 */
+			compatible = "nordic,nrf-pwm";
+			reg = <0x24000 0x1000>;
+			interrupts = <0x24 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "PWM_3";
+			#pwm-cells = <0x1>;
+		};
+
+		pdm@26000 { /* PDM0 */
+			compatible = "nordic,nrf-pdm";
+			reg = <0x26000 0x1000>;
+			interrupts = <0x26 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "PDM_0";
+		};
+
+		i2s@28000 { /* I2S0 */
+			compatible = "nordic,nrf-i2s";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0x28000 0x1000>;
+			interrupts = <0x28 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "I2S_0";
+		};
+
+		ipc@2a000 { /* IPC */
+			compatible = "nordic,nrf-ipc";
+			reg = <0x2a000 0x1000>;
+			interrupts = <0x2a NRF_DEFAULT_IRQ_PRIORITY>;
+			label = "IPC";
+		};
+
+		qspi@2b000 { /* QSPI */
+			compatible = "nordic,nrf-qspi";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0x2b000 0x1000>;
+			interrupts = <0x2b NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "QSPI";
+		};
+
+		/* skipped: NFCT */
+
+		/* skipped: MUTEX */
+
+		qdec@33000 { /* QDEC0 */
+			compatible = "nordic,nrf-qdec";
+			reg = <0x33000 0x1000>;
+			interrupts = <0x33 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "QDEC_0";
+		};
+
+		qdec@34000 { /* QDEC1 */
+			compatible = "nordic,nrf-qdec";
+			reg = <0x34000 0x1000>;
+			interrupts = <0x34 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "QDEC_1";
+		};
+
+		usbd@36000 { /* USBD */
+			compatible = "nordic,nrf-usbd";
+			reg = <0x36000 0x1000>;
+			interrupts = <0x36 NRF_DEFAULT_IRQ_PRIORITY>;
+			num-bidir-endpoints = <0x1>;
+			num-in-endpoints = <0x7>;
+			num-out-endpoints = <0x7>;
+			num-isoin-endpoints = <0x1>;
+			num-isoout-endpoints = <0x1>;
+			status = "disabled";
+			label = "USBD";
+		};
+
+		/* skipped: USBREGULATOR */
+
+		kmu@39000 { /* KMU */
+			compatible = "nordic,nrf-kmu";
+			reg = <0x39000 0x1000>;
+			interrupts = <0x39 NRF_DEFAULT_IRQ_PRIORITY>;
+		};
+
+		flash-controller@39000 { /* NVMC */
+			compatible = "nordic,nrf53-flash-controller";
+			reg = <0x39000 0x1000>;
+			#address-cells = <0x1>;
+			#size-cells = <0x1>;
+			label = "APP_NVMC";
+		};
+
+		gpio@842500 { /* P0 */
+			compatible = "nordic,nrf-gpio";
+			gpio-controller;
+			reg = <0x842500 0x300>;
+			#gpio-cells = <0x2>;
+			label = "GPIO_0";
+			status = "disabled";
+			port = <0x0>;
+		};
+
+		gpio@842800 { /* P1 */
+			compatible = "nordic,nrf-gpio";
+			gpio-controller;
+			reg = <0x842800 0x300>;
+			#gpio-cells = <0x2>;
+			ngpios = <0x10>;
+			label = "GPIO_1";
+			status = "disabled";
+			port = <0x1>;
+		};
+
+		vmc@81000 { /* VMC */
+			compatible = "nordic,nrf-vmc";
+			reg = <0x81000 0x1000>;
+		};
+	};
+
+	/* Network resources ----------------------------------------------- */
+
+	net_core_components: net-core-components {
+		/* Network core, core components. */
+		compatible = "indirect-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		ficr@1ff0000 {
+			compatible = "nordic,nrf-ficr";
+			reg = <0x01ff0000 0x1000>;
+			status = "okay";
+		};
+
+		uicr@1ff8000 {
+			compatible = "nordic,nrf-uicr";
+			reg = <0x01ff8000 0x1000>;
+			status = "okay";
+		};
+	};
+
+	net_mem: net-mem {
+		/* Network core memories. */
+		compatible = "indirect-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		flash@1000000 {
+			compatible = "soc-nv-flash";
+			label = "NRF_FLASH";
+			erase-block-size = <2048>;
+			write-block-size = <4>;
+		};
+
+		memory@21000000 {
+			compatible = "mmio-sram";
+			reg = <0x21000000 DT_SIZE_K(64)>;
+		};
+	};
+
+	net_ppb: net-ppb {
+		/* Net core Arm private peripheral bus */
+		compatible = "indirect-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* skipped: CTI */
+
+		/include/ "armv8-m-ppb.dtsi"
+	};
+
+	net_peripherals: net-peripherals {
+		compatible = "indirect-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* skipped: DCNF */
+
+		/* skipped: VREQCTRL */
+
+		clock@41005000 { /* CLOCK */
+			compatible = "nordic,nrf-clock";
+			reg = <0x41005000 0x1000>;
+			interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
+			label = "CLOCK";
+		};
+
+		power@41005000 { /* POWER */
+			compatible = "nordic,nrf-power";
+			reg = <0x41005000 0x1000>;
+			interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
+		};
+
+		/* skipped: RESET */
+
+		/* skipped: CTRLAPPERI */
+
+		radio@41008000 { /* RADIO */
+			compatible = "nordic,nrf-radio";
+			reg = <0x41008000 0x1000>;
+			interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
+			dfe-antenna-num = <0>;
+			dfe-pdu-antenna = <0xFF>;
+		};
+
+		random@41009000 { /* RNG */
+			compatible = "nordic,nrf-rng";
+			reg = <0x41009000 0x1000>;
+			interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
+			label = "RNG";
+		};
+
+		gpiote@4100a000 { /* GPIOTE */
+			compatible = "nordic,nrf-gpiote";
+			reg = <0x4100a000 0x1000>;
+			interrupts = <10 5>;
+			status = "disabled";
+			label = "GPIOTE_0";
+		};
+
+		watchdog@4100b000 { /* WDT */
+			compatible = "nordic,nrf-watchdog";
+			reg = <0x4100b000 0x1000>;
+			interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
+			label = "WDT";
+		};
+
+		timer@4100c000 { /* TIMER0 */
+			compatible = "nordic,nrf-timer";
+			status = "disabled";
+			reg = <0x4100c000 0x1000>;
+			cc-num = <8>;
+			interrupts = <12 NRF_DEFAULT_IRQ_PRIORITY>;
+			prescaler = <0>;
+			label = "TIMER0";
+		};
+
+		ecb@4100d000 {	/* ECB */
+			compatible = "nordic,nrf-ecb";
+			reg = <0x4100d000 0x1000>;
+			interrupts = <13 NRF_DEFAULT_IRQ_PRIORITY>;
+			label = "ECB";
+		};
+
+		/* skipped: AAR */
+
+		/* skipped: CCM */
+
+		dppic@4100f000 { /* DPPIC */
+			compatible = "nordic,nrf-dppic";
+			reg = <0x4100f000 0x1000>;
+			label = "DPPIC";
+		};
+
+		temp@41010000 {	/* TEMP */
+			compatible = "nordic,nrf-temp";
+			reg = <0x41010000 0x1000>;
+			interrupts = <16 NRF_DEFAULT_IRQ_PRIORITY>;
+			label = "TEMP_0";
+		};
+
+		rtc@41011000 {	/* RTC0 */
+			compatible = "nordic,nrf-rtc";
+			reg = <0x41011000 0x1000>;
+			cc-num = <4>;
+			interrupts = <17 NRF_DEFAULT_IRQ_PRIORITY>;
+			label = "RTC_0";
+		};
+
+		ipc@41012000 {	/* IPC */
+			compatible = "nordic,nrf-ipc";
+			reg = <0x41012000 0x1000>;
+			interrupts = <18 NRF_DEFAULT_IRQ_PRIORITY>;
+			label = "IPC";
+		};
+
+		spi@41013000 {	/* SPIM0 or SPIS0 */
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x41013000 0x1000>;
+			interrupts = <19 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "SPI_0";
+		};
+
+		i2c@41013000 {	/* TWIM0 or TWIS0 */
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x41013000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <19 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "I2C_0";
+		};
+
+		uart@41013000 {	/* UARTE0 */
+			compatible = "nordic,nrf-uarte";
+			reg = <0x41013000 0x1000>;
+			interrupts = <19 NRF_DEFAULT_IRQ_PRIORITY>;
+			status = "disabled";
+			label = "UART_0";
+		};
+
+		egu@41014000 {	/* EGU0 */
+			compatible = "nordic,nrf-egu";
+			reg = <0x41014000 0x1000>;
+			interrupts = <20 NRF_DEFAULT_IRQ_PRIORITY>;
+			label = "EGU_0";
+		};
+
+		rtc@41016000 {	/* RTC1 */
+			compatible = "nordic,nrf-rtc";
+			reg = <0x41016000 0x1000>;
+			cc-num = <4>;
+			interrupts = <22 NRF_DEFAULT_IRQ_PRIORITY>;
+			label = "RTC_1";
+		};
+
+		timer@41018000 { /* TIMER1 */
+			compatible = "nordic,nrf-timer";
+			status = "disabled";
+			reg = <0x41018000 0x1000>;
+			cc-num = <8>;
+			interrupts = <24 NRF_DEFAULT_IRQ_PRIORITY>;
+			prescaler = <0>;
+			label = "TIMER1";
+		};
+
+		timer@41019000 { /* TIMER2 */
+			compatible = "nordic,nrf-timer";
+			status = "disabled";
+			reg = <0x41019000 0x1000>;
+			cc-num = <8>;
+			interrupts = <25 NRF_DEFAULT_IRQ_PRIORITY>;
+			prescaler = <0>;
+			label = "TIMER2";
+		};
+
+		/* skipped: SWI0 */
+
+		/* skipped: SWI1 */
+
+		/* skipped: SWI2 */
+
+		/* skipped: SWI3 */
+
+		/* skipped: ACL */
+
+		flash-controller@41080000 { /* NVMC */
+			compatible = "nordic,nrf53-flash-controller";
+			reg = <0x41080000 0x1000>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			label = "NET_NVMC";
+		};
+
+		vmc@41081000 {	/* VMC */
+			compatible = "nordic,nrf-vmc";
+			reg = <0x41081000 0x1000>;
+		};
+
+		gpio@418c0500 {	/* P0 */
+			compatible = "nordic,nrf-gpio";
+			gpio-controller;
+			reg = <0x418c0500 0x300>;
+			#gpio-cells = <2>;
+			label = "GPIO_0";
+			status = "disabled";
+			port = <0>;
+		};
+
+		gpio@418c0800 {	/* P1 */
+			compatible = "nordic,nrf-gpio";
+			gpio-controller;
+			reg = <0x418c0800 0x300>;
+			#gpio-cells = <2>;
+			ngpios = <16>;
+			label = "GPIO_1";
+			status = "disabled";
+			port = <1>;
+		};
+	};
+};

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+HERE=$(dirname $(realpath $0))
+
+cd "$HERE"
+
+set -x
+
+lopper.py -f -O. -i lop-cpuapp.dts nrf5340_system.dts out-cpuapp.dts
+lopper.py -f -O. -i lop-cpunet.dts nrf5340_system.dts out-cpunet.dts


### PR DESCRIPTION
That's in nrf5340_system.dts, and is based on various related files in
the zephyr tree. I sometimes left out some nodes where the upstream
zephyr DTS doesn't have them, but those are annotated with 'skipped:'
comments. I also removed a bunch of node labels that would cause
duplicates in a single file.

If you run run.sh, you'll get two files: out-cpuapp.dts and
out-cpunet.dts. These are the results of running lopper on
nrf5340_system.dts to move the relevant cpu cluster to /cpus.

This is just meant as a starting point and sanity check that this SDT
is acceptable to the tool. You can't get zephyr to boot any target on
this SoC with the results.

There are various hardcoded assumptions baked into this that encode a
secure-only view of the world and should be followed up on. See
'FIXME' comments.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>